### PR TITLE
Add support for list and accept friends requests from dashboard

### DIFF
--- a/neosvr_headless_webui/api.py
+++ b/neosvr_headless_webui/api.py
@@ -290,9 +290,37 @@ def invite(client_id, session_id):
     )
     return api_response(response)
 
+@bp.route("/<int:client_id>/friend_requests")
+@api_login_required
+def friend_requests(client_id):
+    try:
+        c = get_headless_client(client_id)
+    except LookupError as exc:
+        return api_response(exc)
+    try:
+        response = c.friend_requests()
+    except HeadlessNotReady as exc:
+        return api_response(exc)
+    return convert_netref(response)
 
-# TODO: Implement `friend_requests` here
-# TODO: Implement `accept_friend_request` here
+@bp.route("/<int:client_id>/accept_friend_request", methods=["POST"])
+@api_login_required
+def accept_friend_request(client_id):
+    try:
+        c = get_headless_client(client_id)
+    except LookupError as exc:
+        return api_response(exc)
+    user = request.form["username"]
+    try:
+        response = c.accept_friend_request(user)
+    except HeadlessNotReady as exc:
+        return api_response(exc)
+    log_user_action(
+        'Accepted contact request of "%s" from client ID %d'
+        % (user, client_id),
+        cmd="acceptFriendRequest",
+    )
+    return api_response(response)
 
 
 @bp.route("/<int:client_id>/worlds")

--- a/neosvr_headless_webui/client.py
+++ b/neosvr_headless_webui/client.py
@@ -70,6 +70,7 @@ def get_client(client_id):
     g.compatibility_hash = client.compatibility_hash
     g.machine_id = client.machine_id
     g.supported_network_protocols = client.supported_network_protocols
+    g.friend_requests = client.friend_requests()
 
     return render_template("client.html")
 

--- a/neosvr_headless_webui/static/js/client.js
+++ b/neosvr_headless_webui/static/js/client.js
@@ -33,3 +33,44 @@ $("#killClientModalForm").submit(function(event) {
     window.location.href = "/dashboard";
   });
 });
+
+// Accept friend request modal (when Accept button is clicked on a user)
+
+$("#acceptFriendRequestModalForm").submit(function(event) {
+  event.preventDefault();
+
+  var $form = $(this),
+    username = $form.find("input[name='username']").val(),
+    url = $form.attr("action");
+
+  var posting = $.post(url, {username: username});
+
+  $("#acceptFriendRequestModal").modal("hide");
+
+  posting.done(function(data) {
+    if (data["success"]) {
+      var toast_title = "Success!"
+      var toast_class = "bg-success";
+    } else {
+      var toast_title = "Error!"
+      var toast_class = "bg-danger";
+    }
+    $(document).Toasts('create', {
+      autohide: true,
+      delay: 10000,
+      class: toast_class,
+      title: toast_title,
+      body: data["message"],
+    });
+  });
+});
+
+// Updates the accept friend request modal when the Accept button is clicked on a user
+
+$('#acceptFriendRequestModal').on('show.bs.modal', function (event) {
+  var button = $(event.relatedTarget)
+  var username = button.data('username')
+  var modal = $(this)
+  modal.find('.modal-body #acceptFriendRequestModalUsernameDisplay').text(username)
+  modal.find('.modal-body #acceptFriendRequestModalUsername').val(username)
+});

--- a/neosvr_headless_webui/templates/client.html
+++ b/neosvr_headless_webui/templates/client.html
@@ -89,6 +89,22 @@
 
       </div>
 
+      <div class="row">
+        <div class="col-xl-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Client info</h3>
+            </div>
+            <div class="card-body">
+              <b>Version:</b> {{ g.version }}<br />
+              <b>Compatibility Hash:</b> <code>{{ g.compatibility_hash }}</code><br />
+              <b>Machine ID: </b> <code>{{ g.machine_id }}</code><br />
+              <b>Supported Network Protocols: </b> {{ ", ".join(g.supported_network_protocols) }}<br />
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div>
 
     <div class="col-xl-6">
@@ -127,15 +143,37 @@
             </div>
           </div>
 
+        </div>
+
+      </div>
+
+      <div class="row">
+        <div class="col-xl-12">
           <div class="card">
             <div class="card-header">
-              <h3 class="card-title">Client info</h3>
+              <h3 class="card-title" style="position: relative; top: 5px;">Contact requests</h3>
             </div>
-            <div class="card-body">
-              <b>Version:</b> {{ g.version }}<br />
-              <b>Compatibility Hash:</b> <code>{{ g.compatibility_hash }}</code><br />
-              <b>Machine ID: </b> <code>{{ g.machine_id }}</code><br />
-              <b>Supported Network Protocols: </b> {{ ", ".join(g.supported_network_protocols) }}<br />
+            <div class="card-body p-0">
+              <table class="table table-striped">
+                <thead>
+                  <tr>
+                    <th scope="col">Username</th>
+                    <th scope="col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for friend_request in g.friend_requests %}
+                  <tr>
+                    <td>{{ friend_request }}</td>
+                    <td>
+                      {% if g.state[0] == "running" %}
+                      <button class="btn btn-success btn-xs" data-toggle="modal" data-target="#acceptFriendRequestModal" data-username="{{ friend_request }}"><b>Accept</b></button>
+                      {% endif %}
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
             </div>
           </div>
 
@@ -198,6 +236,30 @@
     </div>
   </div>
 {% endif %}
+
+<!-- AcceptFriendRequest modal -->
+<div class="modal fade" id="acceptFriendRequestModal" tabindex="-1" role="dialog" aria-labelledby="acceptFriendRequestModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="acceptFriendRequestModalLabel">Contact request</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <form id="acceptFriendRequestModalForm" action="/api/v1/{{ g.client_id }}/accept_friend_request" method="post">
+        <div class="modal-body">
+          Are you sure you want to accept the contact request of <b id="acceptFriendRequestModalUsernameDisplay"></b>?
+          <input type="hidden" id="acceptFriendRequestModalUsername" name="username" value="">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-success">Accept</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
 
 {% endblock %}
 


### PR DESCRIPTION
Hi,

I finally start to look into the WebUI. This pull request add the support for list and accept friend requests directly from the dashboard **but**:

I'm not sure of where to place on the UI the list of the friend requests. As far as I understand the architecture, each `server` can have different NeosVR login (because its possible to precise a NeosVR config file in `autostart.json`) and because of that each NeosVR user can have different contacts. So I put the friend requests list under the session list of the server info tab. And move on the left side the client info card.

In my mind the server info tab looks more: on the left the general information of the server and on the right more detailed information about the server.

Anyway here is how looks my modifications:

![Screenshot 2022-08-07 at 16-53-43 Space Alicorn Network Neos Dashboard](https://user-images.githubusercontent.com/76159594/183297723-e9c61984-515d-45ed-b504-833b5344e4df.png)


Also the code is probably not at the correct place. I want to help but also don't want to put a mess in how you wanted to have done things. So I'm open to the discussion on this subject.

In the future it could maybe be interesting to have a notification center for centralized that one server have a new contact request to accept I think.